### PR TITLE
Added a notebook with transmissions and performance tests

### DIFF
--- a/fit_lc_test.ipynb
+++ b/fit_lc_test.ipynb
@@ -1,6 +1,7 @@
 {
  "metadata": {
-  "name": ""
+  "name": "",
+  "signature": "sha256:8dc38f2069ca4ab8db4071efe47afc6f25929989ea2287eda9017e036b4259db"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -21,17 +22,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "The autoreload extension is already loaded. To reload it, use:\n",
-        "  %reload_ext autoreload\n"
-       ]
-      }
-     ],
-     "prompt_number": 64
+     "outputs": [],
+     "prompt_number": 1
     },
     {
      "cell_type": "code",
@@ -87,7 +79,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 65
+     "prompt_number": 2
     },
     {
      "cell_type": "code",
@@ -99,7 +91,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 66
+     "prompt_number": 3
     },
     {
      "cell_type": "code",
@@ -151,7 +143,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 67
+     "prompt_number": 4
     },
     {
      "cell_type": "code",
@@ -181,7 +173,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 68
+     "prompt_number": 5
     },
     {
      "cell_type": "code",
@@ -192,7 +184,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 69
+     "prompt_number": 6
     },
     {
      "cell_type": "markdown",
@@ -225,7 +217,7 @@
        ]
       }
      ],
-     "prompt_number": 89
+     "prompt_number": 9
     },
     {
      "cell_type": "markdown",
@@ -240,7 +232,7 @@
      "input": [
       "data_Ia =  sncosmo.read_snana_fits('LSST_Ia_HEAD.FITS', 'LSST_Ia_PHOT.FITS')\n",
       "lsst_data=data_Ia[:4]\n",
-      "for i in range(len(data)):\n",
+      "for i in range(len(lsst_data)):\n",
       "    d=lsst_data[i]\n",
       "    lc=get_lsst_lightcurve(d)\n",
       "    lsst_data[i]=lc\n",
@@ -260,7 +252,7 @@
        ]
       }
      ],
-     "prompt_number": 90
+     "prompt_number": 11
     },
     {
      "cell_type": "code",
@@ -282,66 +274,58 @@
       },
       {
        "html": [
-        "&lt;Table masked=False length=40&gt;\n",
-        "<table id=\"table140522556552464\">\n",
-        "<thead><tr><th>mjd</th><th>flux</th><th>flux_error</th><th>filter</th><th>zp</th><th>zpsys</th></tr></thead>\n",
-        "<thead><tr><th>float32</th><th>float32</th><th>float32</th><th>string512</th><th>float64</th><th>string16</th></tr></thead>\n",
-        "<tr><td>0.0</td><td>0.00838084</td><td>0.976129</td><td>lsstr</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>0.016</td><td>-2.64703</td><td>1.52845</td><td>lssti</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>0.028</td><td>-0.430886</td><td>2.33875</td><td>lsstz</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>0.039</td><td>-3.60301</td><td>9.51424</td><td>lsstY</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>12.985</td><td>0.310374</td><td>0.383431</td><td>lsstr</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>12.997</td><td>0.109355</td><td>0.720176</td><td>lssti</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>13.008</td><td>2.58441</td><td>1.19779</td><td>lsstz</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>13.02</td><td>-9.81213</td><td>6.7455</td><td>lsstY</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>35.848</td><td>2.48319</td><td>1.2459</td><td>lsstr</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>35.864</td><td>9.56836</td><td>1.90736</td><td>lssti</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-        "<tr><td>65.907</td><td>4.69723</td><td>1.6338</td><td>lsstz</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>65.926</td><td>8.49284</td><td>6.75189</td><td>lsstY</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>69.871</td><td>-0.54643</td><td>0.605569</td><td>lsstr</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>69.907</td><td>2.02281</td><td>1.02717</td><td>lssti</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>69.918</td><td>3.05719</td><td>1.49241</td><td>lsstz</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>69.926</td><td>0.674151</td><td>9.24922</td><td>lsstY</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>72.875</td><td>0.355057</td><td>0.487867</td><td>lsstr</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>72.907</td><td>2.22115</td><td>0.876832</td><td>lssti</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>72.918</td><td>3.67889</td><td>1.44034</td><td>lsstz</td><td>27.5</td><td>ab</td></tr>\n",
-        "<tr><td>72.926</td><td>-12.0007</td><td>8.90513</td><td>lsstY</td><td>27.5</td><td>ab</td></tr>\n",
-        "</table>"
+        "<table id=\"table4508791120\"><thead><tr><th>mjd</th><th>flux</th><th>flux_error</th><th>filter</th><th>zp</th><th>zpsys</th></tr></thead><tr><td>0.0</td><td>0.00838084</td><td>0.976129</td><td>lsstr</td><td>27.5</td><td>ab</td></tr><tr><td>0.016</td><td>-2.64703</td><td>1.52845</td><td>lssti</td><td>27.5</td><td>ab</td></tr><tr><td>0.028</td><td>-0.430886</td><td>2.33875</td><td>lsstz</td><td>27.5</td><td>ab</td></tr><tr><td>0.039</td><td>-3.60301</td><td>9.51424</td><td>lsstY</td><td>27.5</td><td>ab</td></tr><tr><td>12.985</td><td>0.310374</td><td>0.383431</td><td>lsstr</td><td>27.5</td><td>ab</td></tr><tr><td>12.997</td><td>0.109355</td><td>0.720176</td><td>lssti</td><td>27.5</td><td>ab</td></tr><tr><td>13.008</td><td>2.58441</td><td>1.19779</td><td>lsstz</td><td>27.5</td><td>ab</td></tr><tr><td>13.02</td><td>-9.81213</td><td>6.7455</td><td>lsstY</td><td>27.5</td><td>ab</td></tr><tr><td>35.848</td><td>2.48319</td><td>1.2459</td><td>lsstr</td><td>27.5</td><td>ab</td></tr><tr><td>35.864</td><td>9.56836</td><td>1.90736</td><td>lssti</td><td>27.5</td><td>ab</td></tr><tr><td>35.875</td><td>9.68794</td><td>3.52675</td><td>lsstz</td><td>27.5</td><td>ab</td></tr><tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr><tr><td>65.887</td><td>4.11138</td><td>0.969596</td><td>lssti</td><td>27.5</td><td>ab</td></tr><tr><td>65.907</td><td>4.69723</td><td>1.6338</td><td>lsstz</td><td>27.5</td><td>ab</td></tr><tr><td>65.926</td><td>8.49284</td><td>6.75189</td><td>lsstY</td><td>27.5</td><td>ab</td></tr><tr><td>69.871</td><td>-0.54643</td><td>0.605569</td><td>lsstr</td><td>27.5</td><td>ab</td></tr><tr><td>69.907</td><td>2.02281</td><td>1.02717</td><td>lssti</td><td>27.5</td><td>ab</td></tr><tr><td>69.918</td><td>3.05719</td><td>1.49241</td><td>lsstz</td><td>27.5</td><td>ab</td></tr><tr><td>69.926</td><td>0.674151</td><td>9.24922</td><td>lsstY</td><td>27.5</td><td>ab</td></tr><tr><td>72.875</td><td>0.355057</td><td>0.487867</td><td>lsstr</td><td>27.5</td><td>ab</td></tr><tr><td>72.907</td><td>2.22115</td><td>0.876832</td><td>lssti</td><td>27.5</td><td>ab</td></tr><tr><td>72.918</td><td>3.67889</td><td>1.44034</td><td>lsstz</td><td>27.5</td><td>ab</td></tr><tr><td>72.926</td><td>-12.0007</td><td>8.90513</td><td>lsstY</td><td>27.5</td><td>ab</td></tr></table>"
        ],
        "metadata": {},
        "output_type": "pyout",
-       "prompt_number": 91,
+       "prompt_number": 12,
        "text": [
-        "<Table masked=False length=40>\n",
-        "  mjd      flux    flux_error   filter     zp    zpsys  \n",
-        "float32  float32    float32   string512 float64 string16\n",
-        "------- ---------- ---------- --------- ------- --------\n",
-        "    0.0 0.00838084   0.976129     lsstr    27.5       ab\n",
-        "  0.016   -2.64703    1.52845     lssti    27.5       ab\n",
-        "  0.028  -0.430886    2.33875     lsstz    27.5       ab\n",
-        "  0.039   -3.60301    9.51424     lsstY    27.5       ab\n",
-        " 12.985   0.310374   0.383431     lsstr    27.5       ab\n",
-        " 12.997   0.109355   0.720176     lssti    27.5       ab\n",
-        " 13.008    2.58441    1.19779     lsstz    27.5       ab\n",
-        "  13.02   -9.81213     6.7455     lsstY    27.5       ab\n",
-        " 35.848    2.48319     1.2459     lsstr    27.5       ab\n",
-        " 35.864    9.56836    1.90736     lssti    27.5       ab\n",
-        "    ...        ...        ...       ...     ...      ...\n",
-        " 65.907    4.69723     1.6338     lsstz    27.5       ab\n",
-        " 65.926    8.49284    6.75189     lsstY    27.5       ab\n",
-        " 69.871   -0.54643   0.605569     lsstr    27.5       ab\n",
-        " 69.907    2.02281    1.02717     lssti    27.5       ab\n",
-        " 69.918    3.05719    1.49241     lsstz    27.5       ab\n",
-        " 69.926   0.674151    9.24922     lsstY    27.5       ab\n",
-        " 72.875   0.355057   0.487867     lsstr    27.5       ab\n",
-        " 72.907    2.22115   0.876832     lssti    27.5       ab\n",
-        " 72.918    3.67889    1.44034     lsstz    27.5       ab\n",
-        " 72.926   -12.0007    8.90513     lsstY    27.5       ab"
+        "<Table rows=40 names=('mjd','flux','flux_error','filter','zp','zpsys')>\n",
+        "array([(0.0, 0.00838084239512682, 0.9761290550231934, 'lsstr', 27.5, 'ab'),\n",
+        "       (0.01600000075995922, -2.6470348834991455, 1.5284531116485596, 'lssti', 27.5, 'ab'),\n",
+        "       (0.02800000086426735, -0.43088552355766296, 2.338745355606079, 'lsstz', 27.5, 'ab'),\n",
+        "       (0.039000000804662704, -3.6030075550079346, 9.514240264892578, 'lsstY', 27.5, 'ab'),\n",
+        "       (12.984999656677246, 0.31037437915802, 0.3834307789802551, 'lsstr', 27.5, 'ab'),\n",
+        "       (12.996999740600586, 0.10935536026954651, 0.720176100730896, 'lssti', 27.5, 'ab'),\n",
+        "       (13.008000373840332, 2.5844075679779053, 1.1977941989898682, 'lsstz', 27.5, 'ab'),\n",
+        "       (13.020000457763672, -9.812128067016602, 6.745499134063721, 'lsstY', 27.5, 'ab'),\n",
+        "       (35.847999572753906, 2.4831860065460205, 1.245898962020874, 'lsstr', 27.5, 'ab'),\n",
+        "       (35.86399841308594, 9.568355560302734, 1.9073563814163208, 'lssti', 27.5, 'ab'),\n",
+        "       (35.875, 9.687935829162598, 3.5267515182495117, 'lsstz', 27.5, 'ab'),\n",
+        "       (35.887001037597656, -8.374499320983887, 10.987105369567871, 'lsstY', 27.5, 'ab'),\n",
+        "       (38.85599899291992, 2.0855774879455566, 0.7005829215049744, 'lsstr', 27.5, 'ab'),\n",
+        "       (38.87099838256836, 10.122512817382812, 1.1239503622055054, 'lssti', 27.5, 'ab'),\n",
+        "       (38.882999420166016, 16.64160919189453, 1.9543991088867188, 'lsstz', 27.5, 'ab'),\n",
+        "       (38.89500045776367, 12.576457977294922, 10.854376792907715, 'lsstY', 27.5, 'ab'),\n",
+        "       (41.86000061035156, 1.979806661605835, 0.6496208906173706, 'lsstr', 27.5, 'ab'),\n",
+        "       (41.87099838256836, 7.601950168609619, 1.0419882535934448, 'lssti', 27.5, 'ab'),\n",
+        "       (41.882999420166016, 13.65988826751709, 1.6755282878875732, 'lsstz', 27.5, 'ab'),\n",
+        "       (41.89500045776367, 15.168954849243164, 8.881572723388672, 'lsstY', 27.5, 'ab'),\n",
+        "       (53.86399841308594, 0.08520524203777313, 0.6587751507759094, 'lsstr', 27.5, 'ab'),\n",
+        "       (53.87900161743164, 5.27463436126709, 0.9933618903160095, 'lssti', 27.5, 'ab'),\n",
+        "       (53.89099884033203, 9.061121940612793, 1.478367805480957, 'lsstz', 27.5, 'ab'),\n",
+        "       (53.90299987792969, 4.509251594543457, 7.552627086639404, 'lsstY', 27.5, 'ab'),\n",
+        "       (56.86800003051758, 0.766349196434021, 0.8833580613136292, 'lsstr', 27.5, 'ab'),\n",
+        "       (56.882999420166016, 5.684971332550049, 1.50240957736969, 'lssti', 27.5, 'ab'),\n",
+        "       (56.89099884033203, 11.039756774902344, 2.1199212074279785, 'lsstz', 27.5, 'ab'),\n",
+        "       (56.90299987792969, 6.278406143188477, 7.557465076446533, 'lsstY', 27.5, 'ab'),\n",
+        "       (65.87100219726562, 1.1705080270767212, 0.5688835978507996, 'lsstr', 27.5, 'ab'),\n",
+        "       (65.88700103759766, 4.111384391784668, 0.969595730304718, 'lssti', 27.5, 'ab'),\n",
+        "       (65.90699768066406, 4.697226047515869, 1.6338021755218506, 'lsstz', 27.5, 'ab'),\n",
+        "       (65.9260025024414, 8.492842674255371, 6.751889705657959, 'lsstY', 27.5, 'ab'),\n",
+        "       (69.87100219726562, -0.5464296340942383, 0.6055691838264465, 'lsstr', 27.5, 'ab'),\n",
+        "       (69.90699768066406, 2.0228075981140137, 1.027172327041626, 'lssti', 27.5, 'ab'),\n",
+        "       (69.91799926757812, 3.057194232940674, 1.492413878440857, 'lsstz', 27.5, 'ab'),\n",
+        "       (69.9260025024414, 0.6741514205932617, 9.249221801757812, 'lsstY', 27.5, 'ab'),\n",
+        "       (72.875, 0.3550569415092468, 0.4878668189048767, 'lsstr', 27.5, 'ab'),\n",
+        "       (72.90699768066406, 2.221146821975708, 0.8768320679664612, 'lssti', 27.5, 'ab'),\n",
+        "       (72.91799926757812, 3.6788933277130127, 1.440340280532837, 'lsstz', 27.5, 'ab'),\n",
+        "       (72.9260025024414, -12.000650405883789, 8.905134201049805, 'lsstY', 27.5, 'ab')], \n",
+        "      dtype=[('mjd', '<f4'), ('flux', '<f4'), ('flux_error', '<f4'), ('filter', 'S64'), ('zp', '<f8'), ('zpsys', 'S2')])"
        ]
       }
      ],
-     "prompt_number": 91
+     "prompt_number": 12
     },
     {
      "cell_type": "code",
@@ -359,7 +343,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 73
+     "prompt_number": 13
     },
     {
      "cell_type": "markdown",
@@ -384,7 +368,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 81
+     "prompt_number": 14
     },
     {
      "cell_type": "markdown",
@@ -412,7 +396,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 85
+     "prompt_number": 15
     },
     {
      "cell_type": "markdown",

--- a/transmission_function.ipynb
+++ b/transmission_function.ipynb
@@ -1,0 +1,801 @@
+{
+ "metadata": {
+  "name": "",
+  "signature": "sha256:4d02cb7285bd96ed68753a6453c1cbf2b435318445a3bdec63872df26c106f60"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import os"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 1
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import numpy as np\n",
+      "%matplotlib inline\n",
+      "import matplotlib.pyplot as plt\n",
+      "from astropy.units import Unit"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 20
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "from lsst.sims.photUtils import Bandpass, Sed\n",
+      "import lsst.sims.photUtils.PhotometricParameters as PhotometricParameters"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 3
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "from lsst.sims.photUtils.Photometry import PhotometryBase"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 16
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import sncosmo"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 4
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "from __future__ import division"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 45
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Using the LSST Transmission Functions"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def getlsstbandpassobjs():\n",
+      "    \"\"\"\n",
+      "    General utility to return a list of the baseline LSST bandpasses\n",
+      "    and register them as SNCosmo bandpasses accessible through strings\n",
+      "    like 'LSSTu'.\n",
+      "\n",
+      "    Parameters\n",
+      "    ----------\n",
+      "    plot : bool, optional, defaults to False\n",
+      "        plot filter functions obtained\n",
+      "    Returns\n",
+      "    -------\n",
+      "    None\n",
+      "\n",
+      "    Examples\n",
+      "    --------\n",
+      "    >>> getlsstbandpassobjs()\n",
+      "    \"\"\"\n",
+      "\n",
+      "    from astropy.units import Unit\n",
+      "        \n",
+      "    bandPassList = ['lsstu', 'lsstg', 'lsstr', 'lssti', 'lsstz', 'lssty']\n",
+      "    original_bands = ['u', 'g', 'r', 'i', 'z', 'y']\n",
+      "    banddir = os.path.join(os.getenv('THROUGHPUTS_DIR'), 'baseline')\n",
+      "        \n",
+      "    lsstbands = []\n",
+      "    lsstbp = {}\n",
+      "\n",
+      "    for i in range(len(bandPassList)):\n",
+      "        band=bandPassList[i]\n",
+      "            # setup sncosmo bandpasses\n",
+      "        bandfname = banddir + \"/total_\" + original_bands[i] + '.dat'\n",
+      "\n",
+      "            # register the LSST bands to the SNCosmo registry\n",
+      "            # Not needed for LSST, but useful to compare independent codes\n",
+      "            # Usually the next two lines can be merged,\n",
+      "            # but there is an astropy bug currently which affects only OSX.\n",
+      "        numpyband = np.loadtxt(bandfname)\n",
+      "        sncosmoband = sncosmo.Bandpass(wave=numpyband[:, 0],\n",
+      "                                       trans=numpyband[:, 1],\n",
+      "                                       wave_unit=Unit('nm'),\n",
+      "                                       name=band)\n",
+      "        sncosmo.registry.register(sncosmoband, force=True)\n",
+      "\n",
+      "    return None"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 5
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "getlsstbandpassobjs()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 6
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "model = sncosmo.Model(source='salt2-extended')\n",
+      "model.set(z=0.2)\n",
+      "model.set_source_peakabsmag(-19.3, 'bessellb', 'ab')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 7
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Approximate Transmission Functions for speed"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "pbase = PhotometryBase()\n",
+      "pbase.loadBandpassesFromFiles()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 17
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "bandPassNames = ['u', 'g', 'r', 'i', 'z', 'y']\n",
+      "bandPassLimits = dict()\n",
+      "bandPassLimits['u'] = [300., 450.]\n",
+      "bandPassLimits['g'] = [380., 600.]\n",
+      "bandPassLimits['r'] = [450., 751.]\n",
+      "bandPassLimits['i'] = [600., 900.]\n",
+      "bandPassLimits['z'] = [690., 1100.]\n",
+      "bandPassLimits['y'] = [840., 1100.]"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 18
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "for key in pbase.bandpassDict.keys():\n",
+      "    bp = pbase.bandpassDict[key]\n",
+      "    low = bandPassLimits[key][0]\n",
+      "    high = bandPassLimits[key][1]\n",
+      "    bp.resampleBandpass(wavelen_min=low, wavelen_max=high, wavelen_step=0.5)\n",
+      "    bandpass  = sncosmo.Bandpass(wave=bp.wavelen, trans=bp.sb, wave_unit=Unit('nm'), name='approxLSST_'+key)\n",
+      "    bp.resampleBandpass(wavelen_min=low, wavelen_max=high, wavelen_step=1.0)\n",
+      "    sncosmo.registry.register(bandpass, force=True)\n",
+      "    bandpass  = sncosmo.Bandpass(wave=bp.wavelen, trans=bp.sb, wave_unit=Unit('nm'), name='sparseLSST_'+key)    \n",
+      "    sncosmo.registry.register(bandpass)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 30
+    },
+    {
+     "cell_type": "heading",
+     "level": 3,
+     "metadata": {},
+     "source": [
+      "Speed Comparisons"
+     ]
+    },
+    {
+     "cell_type": "heading",
+     "level": 4,
+     "metadata": {},
+     "source": [
+      "u band"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='LSSTu')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "1000 loops, best of 3: 1.09 ms per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 9
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='approxLSST_u')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 121 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 23
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='sparseLSST_u')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 96.8 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 31
+    },
+    {
+     "cell_type": "heading",
+     "level": 4,
+     "metadata": {},
+     "source": [
+      "g band"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='LSSTg')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "1000 loops, best of 3: 1.1 ms per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 10
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='approxLSST_g')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 137 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 24
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='sparseLSST_g')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='desg')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 103 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 60
+    },
+    {
+     "cell_type": "heading",
+     "level": 4,
+     "metadata": {},
+     "source": [
+      "r band"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='LSSTr')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "1000 loops, best of 3: 1.13 ms per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 11
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='sparseLSST_g')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 107 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 32
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='approxLSST_r')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 160 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 25
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='sparseLSST_r')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 116 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 33
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='desr')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 109 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 59
+    },
+    {
+     "cell_type": "heading",
+     "level": 4,
+     "metadata": {},
+     "source": [
+      "i band"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='LSSTi')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "1000 loops, best of 3: 1.1 ms per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 12
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='approxLSST_i')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 157 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 26
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='sparseLSST_i')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 118 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 34
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='desi')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 111 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 58
+    },
+    {
+     "cell_type": "heading",
+     "level": 4,
+     "metadata": {},
+     "source": [
+      "z band"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='LSSTz')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "1000 loops, best of 3: 1.08 ms per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 13
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='approxLSST_z')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 195 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 27
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='sparseLSST_z')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 132 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 35
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='desz')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 104 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 56
+    },
+    {
+     "cell_type": "heading",
+     "level": 4,
+     "metadata": {},
+     "source": [
+      "y band"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='LSSTy')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "1000 loops, best of 3: 1.09 ms per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 14
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='approxLSST_y')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 147 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 28
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='sparseLSST_y')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 115 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 36
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%timeit model.bandflux(time=0., band='desy')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "10000 loops, best of 3: 92.3 \u00b5s per loop\n"
+       ]
+      }
+     ],
+     "prompt_number": 57
+    },
+    {
+     "cell_type": "heading",
+     "level": 3,
+     "metadata": {},
+     "source": [
+      "Write to Disk"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def writeBandstoDisk(dirname = './', prefix='approxLSST_'):\n",
+      "    import os\n",
+      "    dirname = os.path.abspath(dirname)\n",
+      "    for band in ['u', 'g', 'r', 'i', 'z', 'y']:\n",
+      "        band = prefix + band\n",
+      "        bp = sncosmo.get_bandpass(band)\n",
+      "        fname = band + '_total.dat'\n",
+      "        os.path.join(dirname, fname)\n",
+      "        data = np.array([bp.wave, bp.trans])\n",
+      "        np.savetxt(fname, data.transpose())\n",
+      "    "
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 73
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "writeBandstoDisk()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 74
+    },
+    {
+     "cell_type": "heading",
+     "level": 4,
+     "metadata": {},
+     "source": [
+      "Registering Function"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def registerBands(dirname, prefix=None, suffix=None):\n",
+      "    \n",
+      "    import os\n",
+      "    bands = ['u', 'g', 'r', 'i', 'z', 'y']\n",
+      "    for band in bands:\n",
+      "        fname = os.path.join(dirname, prefix + band + suffix)\n",
+      "        data = np.loadtxt(fname)\n",
+      "        bp = sncosmo.Bandpass(wave=data[:, 0], trans=data[:, 1], name='approxLSST_'+band)\n",
+      "        sncosmo.registry.register(bp, force=True)\n",
+      "    "
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 66
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/transmission_function.ipynb
+++ b/transmission_function.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:4d02cb7285bd96ed68753a6453c1cbf2b435318445a3bdec63872df26c106f60"
+  "signature": "sha256:c616634a133de6f79768d3b2c685e0003d534d2d4fa0b6b05670c191676cb240"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -31,7 +31,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 20
+     "prompt_number": 2
     },
     {
      "cell_type": "code",
@@ -54,7 +54,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 16
+     "prompt_number": 4
     },
     {
      "cell_type": "code",
@@ -65,7 +65,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 4
+     "prompt_number": 5
     },
     {
      "cell_type": "code",
@@ -76,7 +76,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 45
+     "prompt_number": 6
     },
     {
      "cell_type": "heading",
@@ -139,7 +139,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 5
+     "prompt_number": 7
     },
     {
      "cell_type": "code",
@@ -150,7 +150,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 6
+     "prompt_number": 8
     },
     {
      "cell_type": "code",
@@ -163,7 +163,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 7
+     "prompt_number": 9
     },
     {
      "cell_type": "heading",
@@ -183,7 +183,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 17
+     "prompt_number": 10
     },
     {
      "cell_type": "code",
@@ -201,7 +201,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 18
+     "prompt_number": 11
     },
     {
      "cell_type": "code",
@@ -221,7 +221,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 30
+     "prompt_number": 12
     },
     {
      "cell_type": "heading",
@@ -252,11 +252,11 @@
        "output_type": "stream",
        "stream": "stdout",
        "text": [
-        "1000 loops, best of 3: 1.09 ms per loop\n"
+        "1000 loops, best of 3: 1.15 ms per loop\n"
        ]
       }
      ],
-     "prompt_number": 9
+     "prompt_number": 13
     },
     {
      "cell_type": "code",
@@ -271,11 +271,11 @@
        "output_type": "stream",
        "stream": "stdout",
        "text": [
-        "10000 loops, best of 3: 121 \u00b5s per loop\n"
+        "10000 loops, best of 3: 124 \u00b5s per loop\n"
        ]
       }
      ],
-     "prompt_number": 23
+     "prompt_number": 14
     },
     {
      "cell_type": "code",
@@ -290,11 +290,31 @@
        "output_type": "stream",
        "stream": "stdout",
        "text": [
-        "10000 loops, best of 3: 96.8 \u00b5s per loop\n"
+        "10000 loops, best of 3: 98.2 \u00b5s per loop\n"
        ]
       }
      ],
-     "prompt_number": 31
+     "prompt_number": 15
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "truth = model.bandflux(time=0., band='LSSTu')\n",
+      "print model.bandflux(time=0., band='sparseLSST_u') / truth , model.bandflux(time=0., band='approxLSST_u') / truth"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "0.998108348627 0.998119257766\n"
+       ]
+      }
+     ],
+     "prompt_number": 17
     },
     {
      "cell_type": "heading",
@@ -370,6 +390,26 @@
       }
      ],
      "prompt_number": 60
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "truth = model.bandflux(time=0., band='LSSTg')\n",
+      "print model.bandflux(time=0., band='sparseLSST_g') / truth , model.bandflux(time=0., band='approxLSST_g') / truth"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "0.999949042793 0.999936248191\n"
+       ]
+      }
+     ],
+     "prompt_number": 18
     },
     {
      "cell_type": "heading",
@@ -475,6 +515,26 @@
      "prompt_number": 59
     },
     {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "truth = model.bandflux(time=0., band='LSSTr')\n",
+      "print model.bandflux(time=0., band='sparseLSST_r') / truth , model.bandflux(time=0., band='approxLSST_r') / truth"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "0.999870673111 0.99987373329\n"
+       ]
+      }
+     ],
+     "prompt_number": 19
+    },
+    {
      "cell_type": "heading",
      "level": 4,
      "metadata": {},
@@ -557,6 +617,26 @@
       }
      ],
      "prompt_number": 58
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "truth = model.bandflux(time=0., band='LSSTi')\n",
+      "print model.bandflux(time=0., band='sparseLSST_i') / truth , model.bandflux(time=0., band='approxLSST_i') / truth"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "0.999753048567 0.999758036384\n"
+       ]
+      }
+     ],
+     "prompt_number": 20
     },
     {
      "cell_type": "heading",
@@ -643,6 +723,26 @@
      "prompt_number": 56
     },
     {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "truth = model.bandflux(time=0., band='LSSTz')\n",
+      "print model.bandflux(time=0., band='sparseLSST_z') / truth , model.bandflux(time=0., band='approxLSST_z') / truth"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "0.999111241276 0.999109300265\n"
+       ]
+      }
+     ],
+     "prompt_number": 21
+    },
+    {
      "cell_type": "heading",
      "level": 4,
      "metadata": {},
@@ -725,6 +825,26 @@
       }
      ],
      "prompt_number": 57
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "truth = model.bandflux(time=0., band='LSSTy')\n",
+      "print model.bandflux(time=0., band='sparseLSST_y') / truth , model.bandflux(time=0., band='approxLSST_y') / truth"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "0.997842908079 0.99787724581\n"
+       ]
+      }
+     ],
+     "prompt_number": 22
     },
     {
      "cell_type": "heading",


### PR DESCRIPTION
While we are working on a prescription to do this better in SNCosmo, here is a quick notebook with functions to write out approxLSST transmissions to disk and read them in and register them in SNCosmo.

The main problems are that the LSST throughput files are extremely detailed (1 Angstrom sampling) and extended over large wavelength ranges (all filters go from 3000.-12000 Ang). leading to slow flux calculation. The approximate filters are on a sparser grid (5 Ang) and have interpolated values of transmission. The notebook contains a function to write them out to disk, and read them in and register them as SNCosmo functions.

We do a few tests: These tests are done with the SALT2-extended model to get an appropriate wavelength range
- We look at speedup of the basic bandflux calcuation in different bands for a test spectrum using the old LSST filters and these approximate ones. This turns out to be a ~ 10X speedup
- We also test out what error in band fluxes is obtained due to such an approximation. The worst case studied is about 0.3 percent off. 
